### PR TITLE
chore: Validate branding

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,5 +33,3 @@ jobs:
           uses: "hacs/action@main"
           with:
             category: "integration"
-            # Remove this 'ignore' key when you have added brand images for your integration to https://github.com/home-assistant/brands
-            ignore: "brands"


### PR DESCRIPTION
Branding is merged upstream. So it does no longer need to be ignored.