### PR TITLE
Fix HACS install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ If you want to contribute to this please read the [Contribution guidelines](CONT
 [mastodon_profile]: https://chaos.social/@lhw
 [installs]: https://img.shields.io/badge/dynamic/json?logo=home-assistant&logoColor=ccc&label=usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.cloudweatherproxy.total
 [hacs-repo-badge]: https://my.home-assistant.io/badges/hacs_repository.svg
-[hacs-install]: https://my.home-assistant.io/redirect/hacs_repository/?owner=lhw&repository=https%3A%2F%2Fgithub.com%2Flhw%2Fcloudweatherproxy&category=Integration
+[hacs-install]: https://my.home-assistant.io/redirect/hacs_repository/?owner=lhw&repository=cloudweatherproxy&category=Integration


### PR DESCRIPTION
Tried clicking the link as got an error

<img width="607" alt="image" src="https://github.com/user-attachments/assets/0736d6b7-9bf7-4777-9919-bae2223c6c44" />

Setting the repository to just the repo name and not the URL seems to fix it 👍