### PR TITLE
fix: remove backoff in case of failures

### DIFF
--- a/custom_components/cloudweatherproxy/aiocloudweather/server.py
+++ b/custom_components/cloudweatherproxy/aiocloudweather/server.py
@@ -44,10 +44,6 @@ class CloudWeatherListener:
         if self.proxy_enabled:
             self.proxy = CloudWeatherProxy(self.proxy_sinks, self.dns_servers)
 
-        # Track proxy failures per sink so we can stop retrying noisy targets
-        self.proxy_failure_counts: dict[DataSink, int] = {}
-        self.disabled_proxy_sinks: set[DataSink] = set()
-
         # webserver
         self.server: None | web.Server = None
         self.runner: None | web.ServerRunner = None
@@ -79,10 +75,6 @@ class CloudWeatherListener:
 
         if self.proxy_enabled:
             self.proxy = CloudWeatherProxy(self.proxy_sinks, self.dns_servers)
-
-        # Reset failure state on reconfiguration
-        self.proxy_failure_counts.clear()
-        self.disabled_proxy_sinks.clear()
 
     def get_active_proxies(self) -> list[DataSink]:
         """Get the active proxies."""
@@ -206,15 +198,9 @@ class CloudWeatherListener:
                 _LOGGER.debug(
                     "Skipping proxy for sink %s because it is not enabled", sink
                 )
-            elif sink in self.disabled_proxy_sinks:
-                _LOGGER.debug(
-                    "Proxy sink %s is disabled after repeated failures; skipping",
-                    sink,
-                )
             elif self.proxy.session.closed:
-                self.disabled_proxy_sinks.add(sink)
                 _LOGGER.warning(
-                    "CloudWeather proxy forwarding disabled for %s (session closed)",
+                    "CloudWeather proxy session closed for %s; skipping",
                     sink,
                 )
             else:
@@ -229,19 +215,10 @@ class CloudWeatherListener:
                         raise RuntimeError(
                             f"Upstream returned {response.status} for {sink}"
                         )
-                    # Success: reset counter
-                    self.proxy_failure_counts.pop(sink, None)
                 except Exception as err:  # pylint: disable=broad-except
-                    failures = self.proxy_failure_counts.get(sink, 0) + 1
-                    self.proxy_failure_counts[sink] = failures
-                    disable = failures >= 5
-                    if disable:
-                        self.disabled_proxy_sinks.add(sink)
                     _LOGGER.warning(
-                        "CloudWeather proxy error for %s (attempt %d/3)%s: %s",
+                        "CloudWeather proxy error for %s: %s",
                         sink,
-                        failures,
-                        "; disabled" if disable else "",
                         err,
                     )
 


### PR DESCRIPTION
Weathercloud seems unreliable. And without an option to re-enable the sending this is just annoying.

Also its at most one request per minute. So whatever